### PR TITLE
25 cia improvements

### DIFF
--- a/agentlib_mpc/modules/minlp_mpc.py
+++ b/agentlib_mpc/modules/minlp_mpc.py
@@ -24,7 +24,7 @@ class MINLPMPCConfig(BaseMPCConfig):
     def validate_binary_bounds(cls, binary_controls: mpc_datamodels.MPCVariables):
         """Assures all binary variables have 0 and 1 as boundaries."""
         for bc in binary_controls:
-            if bc.ub == 1 and bc.lb == 1:
+            if bc.ub == 1 and bc.lb == 0:
                 continue
             logger.warning(
                 f"Binary variable {bc.name} does not have bounds '0, 1'. This will be"

--- a/agentlib_mpc/modules/mpc.py
+++ b/agentlib_mpc/modules/mpc.py
@@ -326,9 +326,15 @@ class BaseMPC(BaseModule):
         """Takes the solution from optimization backend and sends the first
         step to AgentVariables."""
         self.logger.info("Sending optimal control values to data_broker.")
+        tolerance = 1e-5
         for control in self.var_ref.controls:
             # take the first entry of the control trajectory
             actuation = solution[control][0]
+            # if variables only slightly breach boundaries, clip
+            if self.get(control).ub < actuation < self.get(control).ub + tolerance:
+                actuation = self.get(control).ub
+            if self.get(control).lb - tolerance < actuation < self.get(control).lb:
+                actuation = self.get(control).lb
             self.set(control, actuation)
 
     def set_output(self, solution: Results):

--- a/agentlib_mpc/optimization_backends/casadi_/core/discretization.py
+++ b/agentlib_mpc/optimization_backends/casadi_/core/discretization.py
@@ -185,12 +185,12 @@ class Discretization(abc.ABC):
         # format and return solution
         mpc_output = self._nlp_outputs_to_mpc_outputs(vars_at_optimum=nlp_output["x"])
         # clip binary values within tolerance
-        tolerance = 1e-6
-        mpc_output["w"] = ca.if_else((mpc_output["w"] < 0) &
-                                     (mpc_output["w"] > -tolerance), 0,
-                                     ca.if_else((mpc_output["w"] > 1) &
-                                                (mpc_output["w"] < 1 + tolerance), 1,
-                                                mpc_output["w"]))
+        tolerance = 1e-5
+        mpc_output["w"] = ca.if_else(ca.logic_and(mpc_output["w"] < 0,
+                                                  mpc_output["w"] > -tolerance), 0,
+                          ca.if_else(ca.logic_and(mpc_output["w"] > 1,
+                                                  mpc_output["w"] < 1 + tolerance), 1,
+                          mpc_output["w"]))
 
         self._remember_solution(mpc_output)
         result = self._process_solution(inputs=mpc_inputs, outputs=mpc_output)
@@ -378,7 +378,7 @@ class Discretization(abc.ABC):
         return self.binary_opt_vars
 
     def _create_result_format(
-        self, system: System
+            self, system: System
     ) -> (ca.MX, pd.MultiIndex, list[float], dict[str, list[int]]):
         """
         Creates an MX matrix that includes all inputs and outputs of the nlp
@@ -466,12 +466,12 @@ class Discretization(abc.ABC):
         return output_matrix, result_columns, full_grid, variable_grids
 
     def add_opt_var(
-        self,
-        quantity: OptimizationVariable,
-        lb: ca.MX = None,
-        ub: ca.MX = None,
-        guess: float = None,
-        post_den: str = "",
+            self,
+            quantity: OptimizationVariable,
+            lb: ca.MX = None,
+            ub: ca.MX = None,
+            guess: float = None,
+            post_den: str = "",
     ):
         """
         Create an optimization variable and append to all the associated
@@ -544,12 +544,12 @@ class Discretization(abc.ABC):
         return opt_par
 
     def add_constraint(
-        self,
-        constraint_function: CaFuncInputs,
-        lb: CaFuncInputs = None,
-        ub: CaFuncInputs = None,
-        *,
-        gap_closing: bool = False,
+            self,
+            constraint_function: CaFuncInputs,
+            lb: CaFuncInputs = None,
+            ub: CaFuncInputs = None,
+            *,
+            gap_closing: bool = False,
     ):
         """
         Add a constraint to the optimization problem. If no bounds are given,

--- a/agentlib_mpc/optimization_backends/casadi_/core/discretization.py
+++ b/agentlib_mpc/optimization_backends/casadi_/core/discretization.py
@@ -184,6 +184,14 @@ class Discretization(abc.ABC):
 
         # format and return solution
         mpc_output = self._nlp_outputs_to_mpc_outputs(vars_at_optimum=nlp_output["x"])
+        # clip binary values within tolerance
+        tolerance = 1e-6
+        mpc_output["w"] = ca.if_else((mpc_output["w"] < 0) &
+                                     (mpc_output["w"] > -tolerance), 0,
+                                     ca.if_else((mpc_output["w"] > 1) &
+                                                (mpc_output["w"] < 1 + tolerance), 1,
+                                                mpc_output["w"]))
+
         self._remember_solution(mpc_output)
         result = self._process_solution(inputs=mpc_inputs, outputs=mpc_output)
         return result
@@ -244,7 +252,7 @@ class Discretization(abc.ABC):
         for key, value in inputs.items():
             key: str
             if key.startswith(GUESS_PREFIX):
-                out_key = key[len(GUESS_PREFIX) :]
+                out_key = key[len(GUESS_PREFIX):]
                 inputs[key] = outputs[out_key]
 
         result_matrix = self._result_map(**inputs)["result"]


### PR DESCRIPTION
The CIA example shows boundary violations of ~1e-5, so I adjusted the tolerance to accommodate this. @SteffenEserAC, we can adjust this if you feel the tolerance is too lenient.

Regarding control variable clipping: I originally considered adding a tolerance to `AgentVariable`, but after reviewing its implementation, I decided against it since:
1. `AgentVariable` already has built-in clipping functionality
2. Adding tolerance would affect this existing clipping mechanism
3. It makes more sense for `AgentVariable` to strictly enforce boundaries while letting individual modules handle tolerance as needed