### PR TITLE
Quickfix custom objective

### DIFF
--- a/agentlib_mpc/data_structures/objective.py
+++ b/agentlib_mpc/data_structures/objective.py
@@ -74,6 +74,7 @@ class CompositeWeight:
 class SubObjective:
 
     _warned_names = set()
+    skip_expr = set()
 
     def __init__(
         self,
@@ -92,6 +93,12 @@ class SubObjective:
         self.expression = expressions
         self.weight = weight
         self.name = name or f"obj_{id(self)}"
+        self._check_expressions(expressions)
+
+    def _check_expressions(self, expr) -> None:
+        expr_str = str(expr)
+        if "?" in expr_str or "@" in expr_str:
+            self.skip_expr.add(self.name)
 
     def __add__(self, other):
         """Add two objectives together to create a CombinedObjective"""
@@ -361,6 +368,8 @@ class CombinedObjective:
 
         for obj in self.objectives:
             name = obj.name
+            if name in obj.skip_expr:
+                continue
             if isinstance(obj, ChangePenaltyObjective):
                 # Handle symbolic or numeric weights for control change penalties
                 if isinstance(obj.weight, CasadiParameter):

--- a/agentlib_mpc/optimization_backends/casadi_/core/casadi_backend.py
+++ b/agentlib_mpc/optimization_backends/casadi_/core/casadi_backend.py
@@ -318,6 +318,9 @@ class CasADiBackend(OptimizationBackend):
             self.config.discretization_options.time_step,
         )
         objective_values = objective.calculate_values(results_df, grid)
-        objective_names = [obj.name for obj in objective.objectives] + ["total"]
+        objective_names = []
+        for obj in objective.objectives:
+            if obj.name not in obj.skip_expr:
+                objective_names.append(obj.name)
 
         return objective_names, objective_values

--- a/examples/one_room_mpc/physical/mixed_integer/mixed_integer_mpc_cia.py
+++ b/examples/one_room_mpc/physical/mixed_integer/mixed_integer_mpc_cia.py
@@ -129,7 +129,7 @@ class MyCasadiModel(CasadiModel):
         # Objective function
         objective = sum(
             [
-                self.r_cooling * self.cooling_power,
+                self.r_cooling * abs(self.cooling_power),
                 self.s_T * self.T_slack**2,
             ]
         )


### PR DESCRIPTION
Currently, providing the old notation of the objective only works for common built-in operators. However, using something like ca.if_else breaks the code. This provides a quick fix for this.